### PR TITLE
autoimport games + dev options to limit included games

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,5 @@
+# Include only these minigames
+# VITE_ONLY_MINIGAMES="
+#   amyspark-ng:spam
+#   amyspark-ng:connect
+# "

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 www/main.js
 dist/
+.env*
+!.env*.example

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ Then you can reference this folder in your games like
 }
 ```
 
+## How to dev?!
+You can run dev server and play with:
+```sh
+$ npm install
+$ npm run dev
+```
+
+Or to focus only on the development of your own game, you can do:
+```sh
+$ npm run dev {yourname}:{gamename}
+# for example
+$ npm run dev wario:squeeze
+```
+> There is a one more way to limit games, more in [Advanced testing](#advanced-testing)
+
 ## Default assets
 If you want to use assets created by kaplay, you can use all the assets found in the [crew package](https://github.com/kaplayjs/crew) ! but you have to prefix your sprite with "@"
 ```ts
@@ -47,7 +62,7 @@ You can also use `hidden: true` If you're going to make a game that uses a custo
 ```ts
 game.onMousePress("right", () => bean.jump()) // BAD!! Don't do this :(
 obj.onClick(() => )
-ctx.onButtonPress("click", () => bean.jump()) // GOOD!! Do this :) 
+ctx.onButtonPress("click", () => bean.jump()) // GOOD!! Do this :)
 ```
 - If you're making a mouse minigame and you have an object with an area and you'd like for the cursor to not point at this object, you can tag it with with "ignorepoint"
 ```ts
@@ -62,6 +77,21 @@ ctx.add([
 * `Shift + Q` - Skip minigame
 * `Shift + W` - Restart with speed up
 * `1, 2, 3` - Restart with new difficulty (wanted to make it with shift but it's not working)
-* If you press F2 you'll get a panel that shows some kaplayware info (inputEnabled, score, lives, speed, difficulty, etc) 
+* If you press F2 you'll get a panel that shows some kaplayware info (inputEnabled, score, lives, speed, difficulty, etc)
 
 ![alt text](debug.png)
+
+## Advanced testing
+You can limit the minigames played by their `gameID` with `.env.development` file in the root folder. Copy `.env.development.example` file and save it without `.example` suffix. Then list games in `VITE_ONLY_MINIGAMES` like `{yourname}:{gamename}`, one per line.
+
+For example:
+
+```sh
+# Include only these minigames
+VITE_ONLY_MINIGAMES="
+  amyspark-ng:spam
+  amyspark-ng:connect
+"
+```
+
+Remember to re-run the dev server when you modify it.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "kaplayware",
 	"type": "module",
 	"scripts": {
-		"dev": "vite",
+		"dev": "node scripts/dev.js",
 		"build": "tsc && vite build",
 		"create-game": "node scripts/create.js"
 	},

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,22 +1,19 @@
-import { exec } from "child_process";
-import * as fs from "fs/promises";
+import { spawn } from "child_process";
 
-import { games } from "../src/games.ts";
+const [author, gamePrompt] = (process.argv[2] ?? "").split(":");
+const minigameID = `${author}:${gamePrompt}`;
+const minigameSet = author && gamePrompt;
 
-console.log(games);
+if (minigameSet) {
+  process.env.DEV_MINIGAME = `"${minigameID}"`;
+  console.log(
+    "\u{2728} \x1b[32m\x1b[1mRunning minigame\x1b[0m: \x1b[0m"
+    + minigameID
+  );
+}
 
-// let devMinigame = true;
-// const [author, gamePrompt] = (process.argv[2] ?? "").split(":");
-
-// if (!author || !gamePrompt) {
-// 	devMinigame = false;
-// }
-// else {
-// 	devMinigame = true;
-// 	// const gameToRun = games.find((minigame) => getGameID(minigame) == `${author}:${gamePrompt}`);
-// 	// if (!gameToRun) console.error("WE COULDN'T FIND THAT ONE MINIGAME");
-// 	// else {
-// 	// 	games = games.filter((game) => game == gameToRun);
-// 	// 	console.log("Running: " + getGameID(gameToRun));
-// 	// }
-// }
+spawn(
+  'vite',
+  [...process.argv.slice(minigameSet ? 3 : 2)],
+  { shell: true, stdio: 'inherit' }
+);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+declare const DEV_MINIGAME: string;

--- a/src/games.ts
+++ b/src/games.ts
@@ -1,33 +1,18 @@
-import avoidGame from "../games/amyspark-ng/avoid";
-import connectGame from "../games/amyspark-ng/connect";
-import dodgeGame from "../games/amyspark-ng/dodge";
-import dontGame from "../games/amyspark-ng/dont";
-import flipGame from "../games/amyspark-ng/flip";
-import getGame from "../games/amyspark-ng/get";
-import hitGame from "../games/amyspark-ng/hit";
-import knockGame from "../games/amyspark-ng/knock";
-import slapGame from "../games/amyspark-ng/slap";
-import sortGame from "../games/amyspark-ng/sort";
-import spamGame from "../games/amyspark-ng/spam";
-import spreadGame from "../games/amyspark-ng/spread";
-import uploadGame from "../games/amyspark-ng/upload";
-import chaseGame from "../games/nanopoison/chase";
+import { getGameID } from "./utils";
 
-const games = [
-	// spamGame,
-	// getGame,
-	// chaseGame,
-	// knockGame,
-	// connectGame,
-	// dodgeGame,
-	// sortGame,
-	// hitGame,
-	// avoidGame,
-	// dontGame,
-	// slapGame,
-	// uploadGame,
-	// spreadGame,
-	flipGame,
-];
+const gameModules = import.meta.glob("../games/*/*.ts", { eager: true });
 
-export default games;
+const exclude = new Set(["lajbel:find"]);
+
+const games = Object.values(gameModules)
+	.map((module: any) => module.default)
+	.filter((game) => !exclude.has(getGameID(game)));
+
+const onlyInclude = new Set([
+	DEV_MINIGAME, // Passed arg from npm run dev {yourname}:{gamename}
+	...(import.meta.env?.VITE_ONLY_MINIGAMES ?? "").trim().split("\n").map((s: string) => s.trim()),
+].filter((id) => games.some((game) => getGameID(game) === id)));
+
+export default onlyInclude.size
+	? games.filter((game) => onlyInclude.has(getGameID(game)))
+	: games;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
 		"module": "ESNext",
 		"lib": ["ES2023", "DOM", "DOM.Iterable"],
 		"skipLibCheck": true,
+		"types": ["vite/client"],
+
 		/* Bundler mode */
 		"moduleResolution": "bundler",
 		"allowImportingTsExtensions": true,

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -25,4 +25,7 @@ export default defineConfig(async () => ({
     chunkSizeWarningLimit: 10000,
     sourcemap: "hidden", // makes it so code is obstructed on release
   },
+  define: {
+    DEV_MINIGAME: process.env.DEV_MINIGAME,
+  },
 }));


### PR DESCRIPTION
- Games are imported automatically
- Option to `npm run dev {author}:{prompt}` to develop only one game (optional)
- Env file to limit played games even further, without accidental push of imported games commented out while testing
- ✨included.