### PR TITLE
script replace function to remove invalid chars

### DIFF
--- a/scripts/create.js
+++ b/scripts/create.js
@@ -1,6 +1,8 @@
 import * as fs from "fs/promises";
 
-const [author, gamePrompt] = (process.argv[2] ?? "").split(":");
+let [author, gamePrompt] = (process.argv[2] ?? "").split(":");
+// verify the gameprompt name, to not break class minigame //
+gamePrompt = gamePrompt.replace(/[\s_\-\.]/g, "");
 
 if (!author || !gamePrompt) {
 	console.error("Must specify author and game name");
@@ -21,8 +23,7 @@ const ${gamePrompt}Game: Minigame = {
 	author: "${author}",
 	rgb: [0, 0, 0],
 	urlPrefix: "${assets_dir}",
-	load(ctx) {
-	},
+	load(ctx) {},
 	start(ctx) {
 		const game = ctx.make();
 


### PR DESCRIPTION
While creating a game, I type a name of game with `-` to be a space. After the script is generated, it take that raw string and put it on the string, It generate the script with that invalid raw string, and cause error syntax, I don't know if could be a problem later inside the code but here the simple fix